### PR TITLE
An easier way to update a tools

### DIFF
--- a/MovingSpikeEnemy.gd
+++ b/MovingSpikeEnemy.gd
@@ -9,22 +9,25 @@ enum ANIMATION_TYPE {
 export(ANIMATION_TYPE) var animation_type setget set_animation_type
 export(int) var speed = 1 setget set_speed
 
-onready var animationPlayer: = $AnimationPlayer
+onready var animationPlayer := $AnimationPlayer as AnimationPlayer
 
 func set_animation_type(value):
 	animation_type = value
-	var ap = find_node("AnimationPlayer")
-	if ap: play_updated_animation(ap)
+	_update_animation()
 
 func set_speed(value):
 	speed = value
-	var ap = find_node("AnimationPlayer")
-	if ap: ap.playback_speed = speed
+	_update_animation()
 
 func _ready():
-	play_updated_animation(animationPlayer)
+	_update_animation()
 
-func play_updated_animation(ap):
+func _update_animation():
+	if not animationPlayer:
+		return
+
+	animationPlayer.playback_speed = speed
+
 	match animation_type:
-		ANIMATION_TYPE.LOOP: ap.play("MoveAlongPathLoop")
-		ANIMATION_TYPE.BOUNCE: ap.play("MoveAlongPathBounce")
+		ANIMATION_TYPE.LOOP: animationPlayer.play("MoveAlongPathLoop")
+		ANIMATION_TYPE.BOUNCE: animationPlayer.play("MoveAlongPathBounce")


### PR DESCRIPTION
# Solution

During your video you asked for another way to do updates in tools. This is my way which doesn't need to `find_node`.

Usually I try to move all my update logic into one function. Every `getset` will call that one function after updating their respective variable. In that update function there is a precondition that checks that the necessary dependencies exist, in this case the `animationPlayer`. If any are missing the update is skipped.

# Context

Why is `animationPlayer` `null`? It's because the editor is updating the node before it is ready. This means it isn't in the tree yet. Therefore it has not initialized the `onready` variables yet. This is why you need to manually call the `_update_animation` in `_ready` yourself.